### PR TITLE
Improve extension performance

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -42,13 +42,16 @@
 	
 	let queue = [];
 	function performLog(level, args, date){
-		if (!date){
-			date = new Date();
-		}
-		if (!settings || !settings.isInitialized() || queue.length){
-			queue.push({level, args, date});
-		}
-		else {
+	        if (settings && settings.isInitialized() && !queue.length && settings.logLevel < level){
+	                return;
+	        }
+	        if (!date){
+	                date = new Date();
+	        }
+	        if (!settings || !settings.isInitialized() || queue.length){
+	                queue.push({level, args, date});
+	        }
+	        else {
 			if (settings.logLevel >= level){
 				let pre = "%c[CanvasBlocker] ";
 				if (prefix){

--- a/lib/modifiedCanvasAPI.js
+++ b/lib/modifiedCanvasAPI.js
@@ -55,13 +55,21 @@
 		};
 	}
 	
-	const canvasCache = Object.create(null);
+	const MAX_CACHE_SIZE = 100;
+	const canvasCache = new Map();
+	function addToCache(key, canvas){
+		if (canvasCache.size >= MAX_CACHE_SIZE){
+			const firstKey = canvasCache.keys().next().value;
+			canvasCache.delete(firstKey);
+		}
+		canvasCache.set(key, canvas);
+	}
 	function getFakeCanvas(window, original, prefs){
 		try {
 			let originalDataURL;
 			if (prefs("useCanvasCache")){
 				originalDataURL = original.toDataURL();
-				const cached = canvasCache[originalDataURL];
+				const cached = canvasCache.get(originalDataURL);
 				if (cached){
 					return cached;
 				}
@@ -103,8 +111,8 @@
 			context = window.HTMLCanvasElement.prototype.getContext.call(canvas, "2d");
 			context.putImageData(imageData, 0, 0);
 			if (prefs("useCanvasCache")){
-				canvasCache[originalDataURL] = canvas;
-				canvasCache[canvas.toDataURL()] = canvas;
+				addToCache(originalDataURL, canvas);
+				addToCache(canvas.toDataURL(), canvas);
 			}
 			return canvas;
 		}


### PR DESCRIPTION
## Summary
- avoid constructing log messages when below log level
- limit canvas cache with LRU eviction to keep memory usage down

## Testing
- `npx -y eslint -c .eslintrc.json .`
